### PR TITLE
Identify left and right views

### DIFF
--- a/src/zapcmd_cl_commander.clas.abap
+++ b/src/zapcmd_cl_commander.clas.abap
@@ -12,8 +12,8 @@ CLASS zapcmd_cl_commander DEFINITION
     DATA cf_container_left TYPE REF TO cl_gui_container .
     DATA cf_container_right TYPE REF TO cl_gui_container .
     DATA cf_dirname TYPE REF TO string .
-    DATA cf_filesleft TYPE REF TO zapcmd_cl_filelist .
-    DATA cf_filesright TYPE REF TO zapcmd_cl_filelist .
+    DATA cf_filesleft TYPE REF TO zapcmd_cl_filelist_left .
+    DATA cf_filesright TYPE REF TO zapcmd_cl_filelist_right .
     DATA cf_activelist TYPE REF TO zapcmd_cl_filelist .
 
     METHODS show

--- a/src/zapcmd_cl_filelist_left.clas.abap
+++ b/src/zapcmd_cl_filelist_left.clas.abap
@@ -1,0 +1,32 @@
+CLASS zapcmd_cl_filelist_left DEFINITION
+  PUBLIC
+  INHERITING FROM zapcmd_cl_filelist
+  CREATE PUBLIC.
+
+  PUBLIC SECTION.
+
+    METHODS constructor
+      IMPORTING pf_type TYPE syucomm OPTIONAL
+                pf_dir  TYPE string  OPTIONAL.
+
+  PROTECTED SECTION.
+
+  PRIVATE SECTION.
+
+ENDCLASS.
+
+
+
+CLASS zapcmd_cl_filelist_left IMPLEMENTATION.
+
+
+  METHOD constructor.
+
+    super->constructor( iv_side = gc_side-left
+                        pf_type = pf_type
+                        pf_dir  = pf_dir ).
+
+  ENDMETHOD.
+
+
+ENDCLASS.

--- a/src/zapcmd_cl_filelist_left.clas.xml
+++ b/src/zapcmd_cl_filelist_left.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZAPCMD_CL_FILELIST_LEFT</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>ALV-grid with list of files on the left</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zapcmd_cl_filelist_right.clas.abap
+++ b/src/zapcmd_cl_filelist_right.clas.abap
@@ -1,0 +1,32 @@
+CLASS zapcmd_cl_filelist_right DEFINITION
+  PUBLIC
+  INHERITING FROM zapcmd_cl_filelist
+  CREATE PUBLIC.
+
+  PUBLIC SECTION.
+
+    METHODS constructor
+      IMPORTING pf_type TYPE syucomm OPTIONAL
+                pf_dir  TYPE string  OPTIONAL.
+
+  PROTECTED SECTION.
+
+  PRIVATE SECTION.
+
+ENDCLASS.
+
+
+
+CLASS zapcmd_cl_filelist_right IMPLEMENTATION.
+
+
+  METHOD constructor.
+
+    super->constructor( iv_side = gc_side-right
+                        pf_type = pf_type
+                        pf_dir  = pf_dir ).
+
+  ENDMETHOD.
+
+
+ENDCLASS.

--- a/src/zapcmd_cl_filelist_right.clas.xml
+++ b/src/zapcmd_cl_filelist_right.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZAPCMD_CL_FILELIST_RIGHT</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>ALV-grid with list of files on the right</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zapcmd_if_user_exit.intf.abap
+++ b/src/zapcmd_if_user_exit.intf.abap
@@ -2,10 +2,12 @@ INTERFACE zapcmd_if_user_exit
   PUBLIC.
 
   METHODS change_default_directory
-    CHANGING cv_function_code TYPE syucomm
-             cv_directory     TYPE string.
+    IMPORTING iv_side          TYPE string
+    CHANGING  cv_function_code TYPE syucomm
+              cv_directory     TYPE string.
 
   METHODS change_factories
-    CHANGING ct_factories TYPE zapcmd_tbl_factory.
+    IMPORTING iv_side      TYPE string
+    CHANGING  ct_factories TYPE zapcmd_tbl_factory.
 
 ENDINTERFACE.


### PR DESCRIPTION
Now the class `zapcmd_cl_filelist` is abstract and have two different subclasses for left `zapcmd_cl_filelist_left` and right `zapcmd_cl_filelist` views.

There is a method `get_side` that returns LEFT or RIGHT. Those values are in constants `zapcmd_cl_filelist=>gc_side`

Also defined attributes `gt_fcode_factory` and `gt_factory_button` as instance to avoid use the sames buttons in both views.

Changed the default behaviour for the views at start:
- Left view has no changes, it keeps open frontend files
- Right view now opens by default the application server files